### PR TITLE
Fixed issue that followerData reads from leader device

### DIFF
--- a/Python/flexseapython/flexsea_demo/two_devices_leaderfollower.py
+++ b/Python/flexseapython/flexsea_demo/two_devices_leaderfollower.py
@@ -45,7 +45,7 @@ def fxLeaderFollower(leaderPort, followerPort, baudRate):
 			sleep(0.05)
 
 			leaderData = fxReadDevice(devId0)
-			followerData = fxReadDevice(devId0)
+			followerData = fxReadDevice(devId1)
 
 			angle0 = leaderData.encoderAngle
 			


### PR DESCRIPTION
In the python demo script `two_devices_leaderfollower.py`, the follower data should read from `devId1 `, which was read from `devId0`. 