### PR TITLE
EMBD-659 Try multiple times to activate target bootloader

### DIFF
--- a/Python/flexsea_demo/bootloader.py
+++ b/Python/flexsea_demo/bootloader.py
@@ -34,10 +34,10 @@ def bootloader(fxs, port, baud_rate, target="Mn"):
 	try:
 		print(f"Activating {targets[target]['name']} bootloader", flush=True)
 		sleep(1)
-		print("Sending signal to target device", flush=True)
 		timeout = 60  # seconds
 		while timeout > 0:
 			if timeout%5 == 0:
+				print("Sending signal to target device", flush=True)
 				fxs.activate_bootloader(dev_id, targets[target]["id"])
 			print(f"Waiting for response from target ({timeout}s)", flush=True)
 			sleep(1)

--- a/Python/flexsea_demo/bootloader.py
+++ b/Python/flexsea_demo/bootloader.py
@@ -35,9 +35,10 @@ def bootloader(fxs, port, baud_rate, target="Mn"):
 		print(f"Activating {targets[target]['name']} bootloader", flush=True)
 		sleep(1)
 		print("Sending signal to target device", flush=True)
-		fxs.activate_bootloader(dev_id, targets[target]["id"])
 		timeout = 60  # seconds
 		while timeout > 0:
+			if timeout%5 == 0:
+				fxs.activate_bootloader(dev_id, targets[target]["id"])
 			print(f"Waiting for response from target ({timeout}s)", flush=True)
 			sleep(1)
 			timeout -= 1


### PR DESCRIPTION
# Description

Current Python script is sending activation signal only once and then waits for a minute to get a response from target device. It has been changed. It now tries to activate target bootloader multiple times until timeout occurs.

# Changes

[EMBD-659]

# Test Plan

* Run bootload.sh 

# Expected Results

* Shall be no misfire

# Requirements


[EMBD-659]: https://dephyinc.atlassian.net/browse/EMBD-659