### PR TITLE
EMBD-672 Tunnels for BT and XBee

### DIFF
--- a/Python/flexsea_demo/bootloader.py
+++ b/Python/flexsea_demo/bootloader.py
@@ -88,7 +88,7 @@ def main():
 		dest="target",
 		type=str,
 		default="Mn",
-		choices=["Habs", "Mn", "Reg", "Exe"],
+		choices=["Habs", "Mn", "Reg", "Exe", "BT", "XBee"],
 		help="Target microcontroller",
 	)
 

--- a/Python/flexsea_demo/bootloader.py
+++ b/Python/flexsea_demo/bootloader.py
@@ -20,6 +20,8 @@ def bootloader(fxs, port, baud_rate, target="Mn", timeout=60):
 		"Reg": {"id": 1, "name": "Regulate"},
 		"Exe": {"id": 2, "name": "Execute"},
 		"Mn": {"id": 3, "name": "Manage"},
+		"BT": {"id": 4, "name": "Bluetooth"},
+		"XBee": {"id": 5, "name": "XBee"},
 	}
 
 	if app_type.value == fxe.FX_ACT_PACK.value:

--- a/Python/flexsea_demo/bootloader.py
+++ b/Python/flexsea_demo/bootloader.py
@@ -20,7 +20,7 @@ def bootloader(fxs, port, baud_rate, target="Mn", timeout=60):
 		"Reg": {"id": 1, "name": "Regulate"},
 		"Exe": {"id": 2, "name": "Execute"},
 		"Mn": {"id": 3, "name": "Manage"},
-		"BT": {"id": 4, "name": "Bluetooth"},
+		"BT121": {"id": 4, "name": "Bluetooth"},
 		"XBee": {"id": 5, "name": "XBee"},
 	}
 
@@ -88,7 +88,7 @@ def main():
 		dest="target",
 		type=str,
 		default="Mn",
-		choices=["Habs", "Mn", "Reg", "Exe", "BT", "XBee"],
+		choices=["Habs", "Mn", "Reg", "Exe", "BT121", "XBee"],
 		help="Target microcontroller",
 	)
 


### PR DESCRIPTION
# Description

Added on board radio bootloading support to the python script
[EMBD-672]

# Changes

* New key for BT bootloader
* New key for XBee bootloader

# Test Plan

1. Run the script with BT and XBee options

# Expected Results

* Shall activate intended bootloaders

# Requirements
- [x] Tested on Windows.


[EMBD-672]: https://dephyinc.atlassian.net/browse/EMBD-672