### PR TITLE
python docs auto deploy to dephy.com

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,20 +12,22 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v1
       - name: install pip
-      - uses: BSFishy/pip-action@v1
+        uses: BSFishy/pip-action@v1
         with:
           packages: |
             mkdocs
-      - run: mkdocs build
+      - run: cd ./Python/flexsea/docs
+      - working-directory: ./Python/flexsea
+        run: mkdocs build
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.TOKEN }}
           external_repository: DephyInc/dephy_website
-          publish_dir: ./Python/flexsea/docs
+          publish_dir: ./Python/flexsea/site
           destination_dir: themes/dephytheme/static/documentation
           # keep_files: true
-          user_name: 'noahbuttner'
-          user_email: 'noahbuttner@gmail.com'
-          publish_branch: hugo-files2
+          user_name: ${{ secrets.USER_NAME }}
+          user_email: ${{ secrets.USER_EMAIL }}
+          publish_branch: hugo-files
         #   cname: example.com

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+name: CI
+on:
+  push:
+    branches:
+      - feature/docs_update
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v1
+      - name: install pip
+      - uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            mkdocs
+      - run: mkdocs build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          personal_token: ${{ secrets.TOKEN }}
+          external_repository: DephyInc/dephy_website
+          publish_dir: ./Python/flexsea/docs
+          destination_dir: themes/dephytheme/static/documentation
+          # keep_files: true
+          user_name: 'noahbuttner'
+          user_email: 'noahbuttner@gmail.com'
+          publish_branch: hugo-files2
+        #   cname: example.com

--- a/Python/flexsea/mkdocs.yml
+++ b/Python/flexsea/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: MkLorum
+site_url: https://dephy.com
+nav:
+    - Home: index.md
+theme: readthedocs


### PR DESCRIPTION
# Description

When Python/flexsea/docs/ is updated, mkdocs builds the static website and deploys to the hugo-files branch of dephy_website. This then deploys to the web the latest documentation.

# Changes

Adding Python/flexsea/mkdocs.yml and .github/workflows/docs.yml

# Test Plan

1. Add USER_NAME, USER_EMAIL, and TOKEN secret key value pairs into the github secrets section of this repo. The token variable should be a personal access token with repo access of a user with access to the dephy_website repo.
2. Deploy a change to Python/flexsea/docs/

# Expected Results

* Github action runs
* Code is deployed to dephy_website/hugo-files
* Updated documentation appears on dephy.com/documentation