### PR TITLE
[FX]: skip extra sleeps in set gains if command executed successfully

### DIFF
--- a/flexsea/device.py
+++ b/flexsea/device.py
@@ -490,7 +490,6 @@ class Device:
         # There is a bug either on the C side or in the firmware where,
         # sometimes, the gains aren't set, so we try multiple times
         returnCode = self._FAILURE
-
         for _ in range(5):
             returnCode = self._clib.fxSetGains(self.id, kp, ki, kd, k, b, ff)
             if not be_persistent:

--- a/flexsea/device.py
+++ b/flexsea/device.py
@@ -488,6 +488,8 @@ class Device:
         returnCode = self._FAILURE
         for _ in range(5):
             returnCode = self._clib.fxSetGains(self.id, kp, ki, kd, k, b, ff)
+            if returnCode == self._SUCCESS.value:
+                break
             sleep(0.001)
         if returnCode != self._SUCCESS.value:
             raise RuntimeError("Failed to set gains.")

--- a/flexsea/device.py
+++ b/flexsea/device.py
@@ -459,7 +459,7 @@ class Device:
     # set_gains
     # -----
     @requires_status("connected")
-    def set_gains(self, kp: int, ki: int, kd: int, k: int, b: int, ff: int) -> None:
+    def set_gains(self, kp: int, ki: int, kd: int, k: int, b: int, ff: int, be_persistent: bool = True) -> None:
         """
         Sets the gains used by PID controllers on the device.
 
@@ -482,13 +482,17 @@ class Device:
 
         ff : int
             Feed forward gain.
+        
+        be_persistent : bool
+            Flag indicating whether the command should be sent multiple times
         """
         # There is a bug either on the C side or in the firmware where,
         # sometimes, the gains aren't set, so we try multiple times
         returnCode = self._FAILURE
+
         for _ in range(5):
             returnCode = self._clib.fxSetGains(self.id, kp, ki, kd, k, b, ff)
-            if returnCode == self._SUCCESS.value:
+            if not be_persistent:
                 break
             sleep(0.001)
         if returnCode != self._SUCCESS.value:

--- a/flexsea/device.py
+++ b/flexsea/device.py
@@ -484,7 +484,8 @@ class Device:
             Feed forward gain.
         
         be_persistent : bool
-            Flag indicating whether the command should be sent multiple times
+            Flag indicating whether the command should be sent multiple times.
+            Default value is True. 
         """
         # There is a bug either on the C side or in the firmware where,
         # sometimes, the gains aren't set, so we try multiple times


### PR DESCRIPTION
# Description
 
Updated to `set_gains` method to only repeat attempt at setting gains if response was unsuccessful. 

# Details
We found that the `set_gains` method has a 5x repeated 1 ms sleep in it. This effectively makes the max frequency we can run with continuous gains updates 200 Hz. Ideally, we would like to avoid this if the gains were set successfully on the first try. There is a comment:
```
# There is a bug either on the C side or in the firmware where,
# sometimes, the gains aren't set, so we try multiple times
```
If anyone remembers the main source of this comment, it would be great to know more about this failure case. Will my fix of checking for a successful command work? Or does it fail while still returning a successful result? 